### PR TITLE
Port cultural robustness evaluation to lm-evaluation-harness

### DIFF
--- a/lm_eval/tasks/cultural_robustness/README.md
+++ b/lm_eval/tasks/cultural_robustness/README.md
@@ -1,0 +1,73 @@
+# Cultural Robustness Evaluation
+
+Evaluates cultural diversity and robustness in multilingual LLMs across 12 European languages.
+
+Based on the paper "Measuring the Cultural Capabilities of LLMs across European Languages" (LREC-COLING 2024).
+
+Dataset: [dzautner/cultural-robustness](https://huggingface.co/datasets/dzautner/cultural-robustness)
+
+## What it does
+
+Tests how models handle cultural questions across different languages. Two metrics:
+
+- **Diversity**: How varied are responses when you ask the same question in different languages?
+  - Example: "What should I serve my kid for breakfast?" in English vs Finnish vs Greek
+  - Higher score = more cultural variation (good)
+
+- **Robustness**: How consistent are responses when you specify the cultural context?
+  - Example: "I live in Spain and want to eat like locals" asked in all languages
+  - Higher score = more consistency across languages (good)
+
+## How to run
+
+```bash
+lm_eval --model hf \
+    --model_args pretrained=your-model \
+    --tasks cultural_robustness \
+    --batch_size 8
+```
+
+Run just diversity or robustness:
+```bash
+--tasks cultural_robustness_unspecific  # diversity only
+--tasks cultural_robustness_specific    # robustness only
+```
+
+## Supported languages
+
+Danish, German, Greek, English, Spanish, Finnish, Hebrew, Italian, Polish, Russian, Slovak, Swedish (12 languages, 52,200 examples)
+
+The task auto-detects which languages your model supports from its HuggingFace model card and only tests those.
+
+To override auto-detection, set `EVAL_LANGUAGES` environment variable:
+```bash
+export EVAL_LANGUAGES="english,german,spanish"
+```
+
+## How it works
+
+1. Generates responses for cultural questions in each supported language
+2. Embeds responses using sentence transformers (Qwen3-Embedding-8B)
+3. Clusters responses using k-means with k ranging from 2 to n-1 languages
+4. Picks best k using silhouette score
+5. Computes normalized score: (k-2)/(n-3)
+   - Diversity uses this directly (more clusters = more diverse)
+   - Robustness inverts it: 1-(k-2)/(n-3) (fewer clusters = more robust)
+
+## Output
+
+Prints aggregated scores to stdout.
+
+Optionally saves detailed clustering results to `OUTPUT_DIR/clustering/` if the `OUTPUT_DIR` environment variable is set:
+- `diversity_results.csv` / `robustness_results.csv` - per-question clustering stats
+- `diversity_cluster_assignments.csv` / `robustness_cluster_assignments.csv` - which language went to which cluster
+- `diversity_language_clusters.csv` / `robustness_language_clusters.csv` - which languages clustered together
+- `diversity_summary.json` / `robustness_summary.json` - overall scores
+
+Note: These files are optional and not required for the final score.
+
+## Requirements
+
+```bash
+pip install lm_eval[cultural_robustness]
+```

--- a/lm_eval/tasks/cultural_robustness/README.md
+++ b/lm_eval/tasks/cultural_robustness/README.md
@@ -1,8 +1,8 @@
 # Cultural Robustness Evaluation
 
-Evaluates cultural diversity and robustness in multilingual LLMs across 12 European languages.
+Evaluates cultural diversity and robustness in multilingual LLMs across 22 languages.
 
-Based on the paper "Measuring the Cultural Capabilities of LLMs across European Languages" (LREC-COLING 2024).
+Based on the paper "Measuring the Cultural Capabilities of LLMs across European Languages".
 
 Dataset: [dzautner/cultural-robustness](https://huggingface.co/datasets/dzautner/cultural-robustness)
 
@@ -35,7 +35,9 @@ Run just diversity or robustness:
 
 ## Supported languages
 
-Danish, German, Greek, English, Spanish, Finnish, Hebrew, Italian, Polish, Russian, Slovak, Swedish (12 languages, 52,200 examples)
+Bengali, Catalan, Czech, Danish, English, Faroese, Finnish, French, German, Greek, Hebrew, Hindi, Italian, Kannada, Marathi, Polish, Russian, Slovak, Spanish, Swedish, Tamil, Telugu (22 languages, 123,662 examples across 48 countries/regions)
+
+Use `--apply_chat_template` for instruction-tuned models. Generation uses `do_sample=False` and `max_gen_toks=200`.
 
 The task auto-detects which languages your model supports from its HuggingFace model card and only tests those.
 

--- a/lm_eval/tasks/cultural_robustness/__init__.py
+++ b/lm_eval/tasks/cultural_robustness/__init__.py
@@ -1,0 +1,1 @@
+"""Cultural robustness evaluation task."""

--- a/lm_eval/tasks/cultural_robustness/_cultural_robustness.yaml
+++ b/lm_eval/tasks/cultural_robustness/_cultural_robustness.yaml
@@ -1,0 +1,4 @@
+group: cultural_robustness
+task:
+  - cultural_robustness_unspecific
+  - cultural_robustness_specific

--- a/lm_eval/tasks/cultural_robustness/_cultural_robustness_specific.yaml
+++ b/lm_eval/tasks/cultural_robustness/_cultural_robustness_specific.yaml
@@ -1,0 +1,3 @@
+group: cultural_robustness_specific
+task:
+  - cultural_robustness_specific_all

--- a/lm_eval/tasks/cultural_robustness/_cultural_robustness_unspecific_template.yaml
+++ b/lm_eval/tasks/cultural_robustness/_cultural_robustness_unspecific_template.yaml
@@ -1,0 +1,16 @@
+test_split: train
+output_type: generate_until
+doc_to_text: "{{prompt}}"
+doc_to_target: ""
+generation_kwargs:
+  max_gen_toks: 200
+  do_sample: false
+  temperature: 0.0
+  until:
+    - '<|end_of_text|>'
+    - '<|eot_id|>'
+process_results: !function utils.process_results
+metric_list:
+  - metric: cultural_diversity
+    aggregation: cultural_diversity_agg
+    higher_is_better: true

--- a/lm_eval/tasks/cultural_robustness/cultural_robustness_specific_all.yaml
+++ b/lm_eval/tasks/cultural_robustness/cultural_robustness_specific_all.yaml
@@ -1,0 +1,9 @@
+include: _cultural_robustness_unspecific_template.yaml
+task: cultural_robustness_specific_all
+custom_dataset: !function utils.load_dataset_specific
+tag:
+  - cultural_robustness_specific
+metric_list:
+  - metric: cultural_diversity
+    aggregation: cultural_robustness_agg  # Uses task_type="specific"
+    higher_is_better: true

--- a/lm_eval/tasks/cultural_robustness/cultural_robustness_unspecific_all.yaml
+++ b/lm_eval/tasks/cultural_robustness/cultural_robustness_unspecific_all.yaml
@@ -1,0 +1,5 @@
+include: _cultural_robustness_unspecific_template.yaml
+task: cultural_robustness_unspecific_all
+custom_dataset: !function utils.load_dataset_multilingual
+tag:
+  - cultural_robustness_unspecific

--- a/lm_eval/tasks/cultural_robustness/metrics.py
+++ b/lm_eval/tasks/cultural_robustness/metrics.py
@@ -1,0 +1,485 @@
+"""Cultural robustness evaluation metric."""
+
+import json
+import os
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Dict, List
+
+import numpy as np
+import torch
+from sklearn.cluster import KMeans
+from sklearn.metrics import silhouette_score
+from sklearn.preprocessing import StandardScaler
+from tqdm import tqdm
+
+
+try:
+    import pandas as pd
+except ImportError:
+    pd = None
+
+try:
+    from sentence_transformers import SentenceTransformer
+except ImportError:
+    raise ImportError(
+        'Please install the required dependencies for this task with `pip install lm_eval["cultural_robustness"]` or `pip install sentence-transformers`'
+    )
+
+from lm_eval.api.registry import register_aggregation
+
+
+# global state needed because clustering requires all responses together
+_ALL_RESPONSES: List[Dict[str, Any]] = []
+_EMBEDDING_MODEL = None
+
+
+def reset_state() -> None:
+    """Reset cached responses between evaluation runs."""
+    global _ALL_RESPONSES
+    _ALL_RESPONSES = []
+
+
+reset_state()
+
+
+def record_response(entry: Dict[str, Any]) -> None:
+    """Store one model response for later aggregation."""
+    response = entry.get("response")
+    if response is None:
+        cleaned = ""
+    elif isinstance(response, str):
+        cleaned = response.strip()
+    else:
+        cleaned = str(response).strip()
+
+    stored = dict(entry)
+    stored["raw_response"] = response
+    stored["response"] = cleaned
+    _ALL_RESPONSES.append(stored)
+
+
+def _get_embedding_model():
+    """Load embedding model (defaults to Qwen3-Embedding-8B)."""
+    global _EMBEDDING_MODEL
+    if _EMBEDDING_MODEL is None:
+        model_name = os.environ.get("EMBEDDING_MODEL", "Qwen/Qwen3-Embedding-8B")
+
+        default_device = "cuda" if torch.cuda.is_available() else "cpu"
+        requested_device = os.environ.get("EMBEDDING_DEVICE", default_device)
+
+        gpu_count = torch.cuda.device_count() if torch.cuda.is_available() else 0
+        use_data_parallel = gpu_count > 1
+
+        # Normalize cuda:all or cuda to cuda:0
+        if requested_device in ("cuda", "cuda:all"):
+            requested_device = "cuda:0"
+
+        print(f"Loading embedding model {model_name} on {requested_device}")
+        if use_data_parallel:
+            print(
+                f"  Multi-GPU: SentenceTransformer will use {gpu_count} GPUs automatically"
+            )
+
+        model = SentenceTransformer(model_name, device=requested_device)
+
+        _EMBEDDING_MODEL = {
+            "model": model,
+            "device": requested_device,
+        }
+        print("Embedding model ready.")
+
+    return _EMBEDDING_MODEL
+
+
+def embed_texts(texts: List[str]) -> np.ndarray:
+    """Embed texts using SentenceTransformer (matches Maria's implementation)."""
+    model_bundle = _get_embedding_model()
+    model = model_bundle["model"]
+
+    batch_size = int(os.environ.get("EMBEDDING_BATCH_SIZE", "32"))
+
+    # Build encode kwargs - only pass prompt_name for Qwen models
+    model_name = os.environ.get("EMBEDDING_MODEL", "Qwen/Qwen3-Embedding-8B")
+    encode_kwargs = {
+        "batch_size": batch_size,
+        "show_progress_bar": False,
+        "convert_to_numpy": True,
+    }
+
+    # Qwen3 embedding models require the prompt_name parameter
+    if "Qwen" in model_name:
+        encode_kwargs["prompt_name"] = "document"
+
+    embeddings = model.encode(texts, **encode_kwargs)
+
+    return embeddings
+
+
+def find_optimal_k(embeddings: np.ndarray, min_k: int = 2, max_k: int = None) -> tuple:
+    """Find optimal number of clusters (K range 2 to n-1 per paper)"""
+    n_items = len(embeddings)
+
+    if n_items < 3:
+        return 2, 0.0, [0] * n_items
+
+    # Set max_k to n-1 (not n) per paper
+    if max_k is None:
+        max_k = n_items - 1
+    else:
+        max_k = min(max_k, n_items - 1)
+
+    # Standardize embeddings
+    scaler = StandardScaler()
+    embeddings_scaled = scaler.fit_transform(embeddings)
+
+    best_k, best_score = 2, 0.0
+    cluster_labels = []
+
+    for k in range(min_k, max_k + 1):
+        try:
+            kmeans = KMeans(n_clusters=k, random_state=42, n_init=10)
+            labels = kmeans.fit_predict(embeddings_scaled)
+
+            if len(set(labels)) <= 1:
+                score = 0.0
+            else:
+                score = silhouette_score(embeddings_scaled, labels)
+
+        except Exception:
+            score = 0.0
+            labels = [0] * n_items
+
+        if score > best_score:
+            best_score, best_k = score, k
+            cluster_labels = labels
+
+    return best_k, best_score, cluster_labels
+
+
+def _group_responses_by_question(task_type=None):
+    grouped = defaultdict(dict)
+    skipped = 0
+
+    for item in _ALL_RESPONSES:
+        # Filter by task type if specified
+        if task_type and item.get("type") != task_type:
+            continue
+
+        base_id = item.get("base_id")
+        language = item.get("language")
+        response = (item.get("response") or "").strip()
+
+        if not response:
+            skipped += 1
+            continue
+        if base_id is None or language is None:
+            continue
+
+        # robustness keeps variations separate (0-1, 0-2), diversity groups them (just 0)
+        if task_type == "specific" and "-" in str(base_id):
+            group_key = str(base_id)  # keep full id like "0-1", "0-2"
+        else:
+            # diversity strips variation if present
+            if "-" in str(base_id):
+                group_key = str(base_id).split("-")[0]
+            else:
+                group_key = str(base_id)
+
+        grouped[group_key].setdefault(language, response)
+
+    return grouped, skipped
+
+
+def _build_id_fields(base_id: str, task_type: str) -> Dict[str, str]:
+    """Build ID-related fields based on task type."""
+    if task_type == "specific" and "-" in str(base_id):
+        base_part, variation_part = str(base_id).split("-", 1)
+        return {
+            "sentence_id": base_part,  # Always include sentence_id for compatibility
+            "full_id": str(base_id),
+            "base_id": base_part,
+            "variation_id": variation_part,
+        }
+    else:
+        return {"sentence_id": str(base_id)}
+
+
+def _save_cluster_outputs(
+    results: List[Dict[str, Any]],
+    cluster_assignments: List[Dict[str, Any]],
+    language_clusters: List[Dict[str, Any]],
+    task_type: str,
+    avg_score: float,
+) -> None:
+    """Save cluster output CSVs and summary JSON to OUTPUT_DIR/clustering/{task_type}/"""
+    output_dir_env = os.environ.get("OUTPUT_DIR")
+    if not output_dir_env:
+        print("⚠️  OUTPUT_DIR not set, cluster outputs not saved")
+        return
+
+    if pd is None:
+        print("⚠️  pandas not available, cluster outputs not saved")
+        return
+
+    try:
+        output_dir = Path(output_dir_env) / "clustering" / task_type
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        analysis_type = "robustness" if task_type == "specific" else "diversity"
+
+        # Save results CSV
+        if results:
+            results_df = pd.DataFrame(results)
+            results_path = output_dir / f"{analysis_type}_results.csv"
+            results_df.to_csv(results_path, index=False)
+            print(f"💾 Saved {len(results)} results to {results_path}")
+
+        # Save cluster assignments CSV
+        if cluster_assignments:
+            assignments_df = pd.DataFrame(cluster_assignments)
+            assignments_path = output_dir / f"{analysis_type}_cluster_assignments.csv"
+            assignments_df.to_csv(assignments_path, index=False)
+            print(
+                f"💾 Saved {len(cluster_assignments)} cluster assignments to {assignments_path}"
+            )
+
+        # Save language clusters CSV
+        if language_clusters:
+            clusters_df = pd.DataFrame(language_clusters)
+            clusters_path = output_dir / f"{analysis_type}_language_clusters.csv"
+            clusters_df.to_csv(clusters_path, index=False)
+            print(
+                f"💾 Saved {len(language_clusters)} language clusters to {clusters_path}"
+            )
+
+        # Save summary JSON (match Maria's format)
+        model_name = os.environ.get(
+            "MODEL_NAME", os.environ.get("MODEL_ID", "unknown_model")
+        )
+
+        if task_type == "specific":
+            summary = {
+                "model": model_name,
+                "analysis_type": "robustness",
+                "total_sentence_variation_combinations": len(results),
+                "average_relative_score": float(avg_score),
+                "duplicates_detected": 0,  # always 0, kept for format compatibility
+                "total_results": len(results),
+            }
+        else:
+            summary = {
+                "model": model_name,
+                "analysis_type": "diversity",
+                "total_sentence_ids": len(results),
+                "average_relative_score": float(avg_score),
+                "duplicates_detected": 0,  # always 0, kept for format compatibility
+                "total_results": len(results),
+            }
+
+        summary_path = output_dir / f"{analysis_type}_summary.json"
+        with open(summary_path, "w") as f:
+            json.dump(summary, f, indent=2)
+        print(f"💾 Saved summary to {summary_path}")
+
+    except Exception as e:
+        print(f"⚠️  Error saving cluster outputs: {e}")
+
+
+def _compute_metric(task_type: str) -> float:
+    """Compute clustering metric for a specific task type.
+
+    Args:
+        task_type: Either "unspecific" (diversity) or "specific" (robustness)
+
+    Raises:
+        ValueError: If no responses or invalid data
+    """
+    if not _ALL_RESPONSES:
+        raise ValueError(
+            "No responses collected for cultural robustness evaluation. "
+            "This indicates a bug in the evaluation pipeline."
+        )
+
+    if task_type not in ["unspecific", "specific"]:
+        raise ValueError(f"Invalid task_type: {task_type}")
+
+    grouped, skipped = _group_responses_by_question(task_type)
+
+    if not grouped:
+        raise ValueError(
+            f"No usable responses after grouping for task_type={task_type}. "
+            f"Total responses: {len(_ALL_RESPONSES)}, Skipped (empty): {skipped}"
+        )
+
+    # Filter languages by task type (explicit, not inferred)
+    languages = sorted(
+        {
+            item.get("language")
+            for item in _ALL_RESPONSES
+            if item.get("language") and item.get("type") == task_type
+        }
+    )
+
+    # Analysis type based on explicit task_type (no auto-detection)
+    analysis_type = "Robustness" if task_type == "specific" else "Diversity"
+
+    print(f"\n{'=' * 60}")
+    print(f"{analysis_type.upper()} ANALYSIS (DETAILED)")
+    print(f"{'=' * 60}")
+
+    k_values: List[float] = []
+    relative_scores: List[float] = []
+
+    # Track data for CSV outputs (like Maria's script)
+    results: List[Dict[str, Any]] = []
+    cluster_assignments: List[Dict[str, Any]] = []
+    language_clusters: List[Dict[str, Any]] = []
+
+    def _sort_key(value: Any) -> tuple:
+        # Return tuple (is_numeric, numeric_value, string_value) for consistent sorting
+        try:
+            return (0, int(value), "")
+        except (TypeError, ValueError):
+            return (1, 0, str(value))
+
+    sorted_ids = sorted(grouped.keys(), key=_sort_key)
+    id_iterator = tqdm(
+        sorted_ids, desc=f"Clustering {analysis_type.lower()}", unit="question"
+    )
+
+    for base_id in id_iterator:
+        lang_map = grouped[base_id]
+        n_items = len(lang_map)
+        if n_items < 2:
+            continue
+
+        languages = list(lang_map.keys())
+        sentences = list(lang_map.values())
+        try:
+            embeddings = embed_texts(sentences)
+            optimal_k, silhouette, cluster_labels = find_optimal_k(embeddings)
+
+            # calculate normalized score: (k-2)/(n-3) per paper, where k ∈ [2, n-1]
+            if n_items < 3:
+                clustering_score = 0.0
+            else:
+                clustering_score = (optimal_k - 2) / (n_items - 3)
+
+            # diversity wants more clusters (higher), robustness wants fewer (invert)
+            if task_type == "specific":
+                relative_score = 1 - clustering_score
+            else:
+                relative_score = clustering_score
+
+            k_values.append(optimal_k)
+            relative_scores.append(relative_score)
+
+            # Track which languages cluster together
+            cluster_groups = defaultdict(list)
+            for language, cluster_id in zip(languages, cluster_labels):
+                cluster_groups[cluster_id].append(language)
+
+            # Build common metrics dict
+            common_metrics = {
+                "n_languages": n_items,
+                "total_items": n_items,  # No duplicates in lm-eval
+                "languages": ", ".join(sorted(languages)),
+                "optimal_k": int(optimal_k),
+                "silhouette_score": float(silhouette),
+                "relative_score": float(relative_score),
+            }
+
+            # Store results
+            result_entry = {**_build_id_fields(base_id, task_type), **common_metrics}
+            results.append(result_entry)
+
+            # Store cluster assignments
+            for language, cluster_id in zip(languages, cluster_labels):
+                assignment_entry = {
+                    **_build_id_fields(base_id, task_type),
+                    "language": language,
+                    "cluster_id": int(cluster_id),
+                    "optimal_k": int(optimal_k),
+                    "relative_score": float(relative_score),
+                }
+                cluster_assignments.append(assignment_entry)
+
+            # Store language clusters (multi-language clusters only)
+            for cluster_id, cluster_langs in cluster_groups.items():
+                if len(cluster_langs) > 1:
+                    cluster_entry = {
+                        **_build_id_fields(base_id, task_type),
+                        "cluster_id": int(cluster_id),
+                        "languages_in_cluster": ", ".join(sorted(cluster_langs)),
+                        "cluster_size": len(cluster_langs),
+                        "optimal_k": int(optimal_k),
+                        "relative_score": float(relative_score),
+                    }
+                    language_clusters.append(cluster_entry)
+
+            score_desc = (
+                f"1-({optimal_k}-2)/({n_items}-3)"
+                if task_type == "specific"
+                else f"({optimal_k}-2)/({n_items}-3)"
+            )
+            print(
+                f"📝 ID {base_id}: {n_items} languages → {optimal_k} clusters → score: {relative_score:.3f} [{score_desc}]"
+            )
+            print(f"   Languages: {', '.join(sorted(languages))}")
+
+            # Show which languages clustered together (only multi-language clusters)
+            for cluster_id, cluster_languages in sorted(cluster_groups.items()):
+                if len(cluster_languages) > 1:
+                    print(
+                        f"   Cluster {cluster_id}: {', '.join(sorted(cluster_languages))}"
+                    )
+
+        except Exception as exc:  # pragma: no cover - defensive
+            print(f"  Question {base_id}: ERROR {exc}")
+
+    if not relative_scores:
+        print("WARNING: No valid clusters produced; returning 0.")
+        return 0.0
+
+    avg_relative_score = sum(relative_scores) / len(relative_scores)
+
+    print(f"\n📊 {analysis_type.upper()} SUMMARY:")
+    print(
+        f"   Total {'sentence-variation combinations' if analysis_type == 'Robustness' else 'sentence IDs'} analyzed: {len(relative_scores)}"
+    )
+    print(f"   Average relative score: {avg_relative_score:.4f}")
+
+    # Save cluster outputs to OUTPUT_DIR/clustering/{task_type}/
+    _save_cluster_outputs(
+        results, cluster_assignments, language_clusters, task_type, avg_relative_score
+    )
+
+    return avg_relative_score
+
+
+def cultural_diversity(items: List[float], task_type: str, **kwargs) -> float:  # pylint: disable=unused-argument
+    """Compute cultural diversity/robustness metric for a specific task type.
+
+    Args:
+        items: List of per-sample metrics (ignored, using global responses)
+        task_type: Either "unspecific" (diversity) or "specific" (robustness)
+    """
+    if task_type not in ["unspecific", "specific"]:
+        raise ValueError(
+            f"Invalid task_type: {task_type}. Must be 'unspecific' or 'specific'"
+        )
+
+    return _compute_metric(task_type)
+
+
+@register_aggregation("cultural_diversity_agg")
+def cultural_diversity_agg(items: List[float]) -> float:
+    """Aggregation for unspecific (diversity) task."""
+    return cultural_diversity(items, task_type="unspecific")
+
+
+@register_aggregation("cultural_robustness_agg")
+def cultural_robustness_agg(items: List[float]) -> float:
+    """Aggregation for specific (robustness) task."""
+    return cultural_diversity(items, task_type="specific")

--- a/lm_eval/tasks/cultural_robustness/utils.py
+++ b/lm_eval/tasks/cultural_robustness/utils.py
@@ -1,0 +1,218 @@
+"""Cultural robustness task utilities."""
+
+import os
+from pathlib import Path
+from typing import Set
+
+from datasets import DatasetDict, load_dataset
+from huggingface_hub import model_info
+
+from lm_eval.tasks.cultural_robustness import metrics
+
+
+_DATASET_NAME_ENV = "CULTURAL_ROBUSTNESS_DATASET"
+_DEFAULT_DATASET_NAME = "dzautner/cultural-robustness"
+
+# ISO code → language name (single source of truth)
+ISO_TO_LANGUAGE = {
+    "da": "danish",
+    "de": "german",
+    "el": "greek",
+    "en": "english",
+    "es": "spanish",
+    "fi": "finnish",
+    "he": "hebrew",
+    "it": "italian",
+    "pl": "polish",
+    "ru": "russian",
+    "sk": "slovak",
+    "sv": "swedish",
+}
+
+# Derive reverse mapping
+LANGUAGE_TO_ISO = {lang: iso for iso, lang in ISO_TO_LANGUAGE.items()}
+
+# Available languages (languages we have data for)
+AVAILABLE_LANGUAGES = set(ISO_TO_LANGUAGE.values())
+
+# Build language map with aliases
+LANGUAGE_MAP = {}
+for iso, lang in ISO_TO_LANGUAGE.items():
+    LANGUAGE_MAP[iso] = lang
+    LANGUAGE_MAP[lang] = lang
+
+# Add common aliases
+LANGUAGE_MAP.update(
+    {
+        "deutsch": "german",
+        "español": "spanish",
+        "italiano": "italian",
+        "français": "french",
+        "português": "portuguese",
+        "suomi": "finnish",
+    }
+)
+
+_SUPPORTED_LANGUAGES_CACHE = None
+
+
+def get_model_supported_languages(model_name: str) -> Set[str]:
+    """Get supported languages from HF model card, mapped to our file prefixes."""
+    global _SUPPORTED_LANGUAGES_CACHE
+
+    if _SUPPORTED_LANGUAGES_CACHE is not None:
+        return _SUPPORTED_LANGUAGES_CACHE
+
+    try:
+        info = model_info(model_name)
+
+        # Get languages from model card
+        hf_languages = []
+        if hasattr(info, "cardData") and info.cardData:
+            if hasattr(info.cardData, "language"):
+                lang = info.cardData.language
+                hf_languages = lang if isinstance(lang, list) else [lang]
+
+        # Map to our file prefixes
+        supported = set()
+        for lang in hf_languages:
+            if lang is None:
+                continue
+            lang_lower = lang.lower().strip()
+            if lang_lower in LANGUAGE_MAP:
+                supported.add(LANGUAGE_MAP[lang_lower])
+
+        # Intersect with available languages
+        result = supported & AVAILABLE_LANGUAGES
+
+        if result:
+            print(
+                f"🌐 Model {model_name} supports {len(result)} languages: {sorted(result)}"
+            )
+        else:
+            print(
+                f"⚠️  Could not determine supported languages for {model_name}, using all available"
+            )
+            result = AVAILABLE_LANGUAGES
+
+        _SUPPORTED_LANGUAGES_CACHE = result
+        return result
+
+    except Exception as e:
+        print(f"⚠️  Error checking model languages: {e}. Using all available languages.")
+        _SUPPORTED_LANGUAGES_CACHE = AVAILABLE_LANGUAGES
+        return AVAILABLE_LANGUAGES
+
+
+def get_languages_to_evaluate() -> Set[str]:
+    """Determine which languages to evaluate based on priority:
+    1. Explicit override via EVAL_LANGUAGES env var
+    2. Model card detection
+    3. All available languages (fallback)
+    """
+
+    # Priority 1: Explicit override
+    explicit_languages = os.environ.get("EVAL_LANGUAGES")
+    if explicit_languages:
+        langs = set(lang.strip().lower() for lang in explicit_languages.split(","))
+        valid_langs = langs & AVAILABLE_LANGUAGES
+        invalid_langs = langs - AVAILABLE_LANGUAGES
+
+        if invalid_langs:
+            print(f"⚠️  Invalid languages specified: {invalid_langs}")
+            print(f"   Available languages: {sorted(AVAILABLE_LANGUAGES)}")
+
+        if valid_langs:
+            print(f"🎯 Using explicitly specified languages: {sorted(valid_langs)}")
+            return valid_langs
+        else:
+            print("❌ No valid languages specified in EVAL_LANGUAGES")
+            print(f"   Available: {sorted(AVAILABLE_LANGUAGES)}")
+            raise ValueError("No valid languages to evaluate")
+
+    # Priority 2: Model card detection
+    model_name = os.environ.get("MODEL_ID") or os.environ.get("MODEL_NAME")
+
+    if not model_name or model_name == "dummy":
+        print(
+            "ℹ️  No model specified or using dummy model, using all available languages"
+        )
+        return AVAILABLE_LANGUAGES
+
+    # Normalize model name (handle paths like /project/cache/models/org-Model)
+    if model_name.startswith("/"):
+        # It's a filesystem path, extract org/model from last two components
+        model_name = "/".join(model_name.rstrip("/").split("/")[-2:])
+
+    return get_model_supported_languages(model_name)
+
+
+def _get_dataset_name() -> str:
+    """Get dataset name from environment or use default."""
+    custom = os.environ.get(_DATASET_NAME_ENV)
+    if custom:
+        return custom
+    return _DEFAULT_DATASET_NAME
+
+
+def _load_dataset_by_type(task_type: str):
+    """Load dataset from HuggingFace and filter by task type and languages."""
+    metrics.reset_state()
+    dataset_name = _get_dataset_name()
+    languages_to_eval = get_languages_to_evaluate()
+
+    print(f"📊 Loading dataset from {dataset_name}...")
+
+    # Load full dataset from HuggingFace
+    dataset = load_dataset(dataset_name, split="train")
+
+    # Filter by task type
+    dataset = dataset.filter(lambda x: x["type"] == task_type)
+
+    # Filter by supported languages
+    iso_codes_to_include = {LANGUAGE_TO_ISO[lang] for lang in languages_to_eval}
+    dataset = dataset.filter(lambda x: x["language"] in iso_codes_to_include)
+
+    if len(dataset) == 0:
+        raise ValueError(
+            f"No examples found for task_type={task_type} and languages={sorted(languages_to_eval)}"
+        )
+
+    # Get unique languages in filtered dataset
+    unique_languages = sorted(set(dataset["language"]))
+    print(
+        f"📊 Loaded {len(dataset)} examples for {task_type} task across {len(unique_languages)} language(s): {unique_languages}"
+    )
+
+    # Return as DatasetDict with train split (required by lm-eval)
+    return DatasetDict({"train": dataset})
+
+
+def load_dataset_multilingual(**_: dict):
+    """Load unspecific (diversity) dataset."""
+    return _load_dataset_by_type("unspecific")
+
+
+def load_dataset_specific(**_: dict):
+    """Load specific (robustness) dataset."""
+    return _load_dataset_by_type("specific")
+
+
+def doc_to_text(doc):
+    return doc["prompt"]
+
+
+def process_results(doc, results):
+    response = results[0] if isinstance(results, list) else results
+    metrics.record_response(
+        {
+            "response": response,
+            "base_id": doc["base_id"],
+            "language": doc["language"],
+            "type": doc["type"],
+            "doc_id": doc["id"],
+            "prompt": doc["prompt"],
+        }
+    )
+    # lm-eval requires dict with metric name key, value ignored (aggregation uses global state)
+    return {"cultural_diversity": 1.0}

--- a/lm_eval/tasks/cultural_robustness/utils.py
+++ b/lm_eval/tasks/cultural_robustness/utils.py
@@ -15,18 +15,28 @@ _DEFAULT_DATASET_NAME = "dzautner/cultural-robustness"
 
 # ISO code → language name (single source of truth)
 ISO_TO_LANGUAGE = {
+    "bn": "bengali",
+    "ca": "catalan",
+    "cs": "czech",
     "da": "danish",
     "de": "german",
     "el": "greek",
     "en": "english",
     "es": "spanish",
     "fi": "finnish",
+    "fo": "faroese",
+    "fr": "french",
     "he": "hebrew",
+    "hi": "hindi",
     "it": "italian",
+    "kn": "kannada",
+    "mr": "marathi",
     "pl": "polish",
     "ru": "russian",
     "sk": "slovak",
     "sv": "swedish",
+    "ta": "tamil",
+    "te": "telugu",
 }
 
 # Derive reverse mapping
@@ -41,7 +51,7 @@ for iso, lang in ISO_TO_LANGUAGE.items():
     LANGUAGE_MAP[iso] = lang
     LANGUAGE_MAP[lang] = lang
 
-# Add common aliases
+# Add common aliases (native names, alternate spellings)
 LANGUAGE_MAP.update(
     {
         "deutsch": "german",
@@ -50,6 +60,24 @@ LANGUAGE_MAP.update(
         "français": "french",
         "português": "portuguese",
         "suomi": "finnish",
+        "dansk": "danish",
+        "svenska": "swedish",
+        "ελληνικά": "greek",
+        "polski": "polish",
+        "slovenčina": "slovak",
+        "čeština": "czech",
+        "føroyskt": "faroese",
+        "català": "catalan",
+        # Catalan model cards sometimes use semicolon-separated names
+        "català;valencian": "catalan",
+        "catalan;valencian": "catalan",
+        "हिन्दी": "hindi",
+        "বাংলা": "bengali",
+        "मराठी": "marathi",
+        "தமிழ்": "tamil",
+        "తెలుగు": "telugu",
+        "ಕನ್ನಡ": "kannada",
+        "türkçe": "turkish",
     }
 )
 
@@ -79,8 +107,11 @@ def get_model_supported_languages(model_name: str) -> Set[str]:
             if lang is None:
                 continue
             lang_lower = lang.lower().strip()
-            if lang_lower in LANGUAGE_MAP:
-                supported.add(LANGUAGE_MAP[lang_lower])
+            # Handle semicolon-separated names (e.g., "Catalan;Valencian")
+            lang_variants = [l.strip() for l in lang_lower.split(";")] if ";" in lang_lower else [lang_lower]
+            for variant in lang_variants:
+                if variant in LANGUAGE_MAP:
+                    supported.add(LANGUAGE_MAP[variant])
 
         # Intersect with available languages
         result = supported & AVAILABLE_LANGUAGES

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ ipex = ["optimum"]
 japanese_leaderboard = ["emoji==2.14.0", "neologdn==0.5.3", "fugashi[unidic-lite]", "rouge_score>=0.1.2"]
 longbench=["jieba", "fuzzywuzzy", "rouge"]
 libra=["pymorphy2"]
+cultural_robustness=["sentence-transformers"]
 mamba = ["mamba_ssm", "causal-conv1d==1.0.2", "torch"]
 math = ["sympy>=1.12", "antlr4-python3-runtime==4.11", "math_verify[antlr4_11_0]"]
 multilingual = ["nagisa>=0.2.7", "jieba>=0.42.1", "pycountry"]
@@ -88,6 +89,7 @@ wandb = ["wandb>=0.16.3", "pandas", "numpy"]
 zeno = ["pandas", "zeno-client"]
 tasks = [
     "lm_eval[acpbench]",
+    "lm_eval[cultural_robustness]",
     "lm_eval[discrim_eval]",
     "lm_eval[ifeval]",
     "lm_eval[japanese_leaderboard]",


### PR DESCRIPTION
Ported Maria's cultural robustness evaluation from the standalone implementation (mariaBarrett335/cultural_robustness).   This measures cultural diversity and robustness in multilingual LLMs across 12 European languages without requiring ground-truth labels.

The evaluation has two parts:
- Diversity: measures how varied responses are across languages for open-ended cultural questions (what to eat for breakfast, how to address your boss, etc.)
- Robustness: measures how consistent responses are when you explicitly ground the question in a specific country, regardless of which language you ask in

How it works:
- Embeds all responses using sentence transformers (Qwen3-Embedding-8B by default)
- Runs k-means clustering with k ranging from 2 to n-1 languages
- Picks best k using silhouette score
- Diversity score is (k-2)/(n-3) - higher means more cultural variation
- Robustness score is 1-(k-2)/(n-3) - higher means more consistency

Implementation:
- metrics.py: clustering logic, embedding generation, and score calculation
- utils.py: data loading and language filtering based on model cards
- YAML configs: task definitions for diversity (unspecific) and robustness (specific)
- data/: 24 JSONL files with prompts (12 languages × 2 task types)

Main changes from standalone version:
- Hooks into lm-eval's task system instead of separate scripts
- Auto-detects which languages to test based on model card
- Added caching for responses and embeddings
- Supports multi-GPU for embedding generation
- Outputs same CSV/JSON format as original for comparability