### PR TITLE
English and Finnish Math-500 evals with more sensible prompting

### DIFF
--- a/lm_eval/tasks/lumiopen/README.md
+++ b/lm_eval/tasks/lumiopen/README.md
@@ -1,0 +1,14 @@
+# LumiOpen evaluations
+## Math-500
+We provide our own implementation of Math-500. This combines elements from the hendrycks_math500 included in lm-eval-harness and the Math-500 implementation from lighteval. The main motivation for this is that the lighteval implementation is better suited for instruction and reasoning tuned models. In comparison to the hendrycks_math500, we utilize prompts tailored for instruction tuned models and improve the parsing and normalization of the generated answer.
+
+We also provide a machine translated Finnish version of Math-500.
+
+### Math-500 implementation comparison
+As the implementations have drastic differences, the scores also contain some variance.
+Some numbers for comparison are listed below.
+
+| Model                    | Lighteval Math-500 | hendrycks_math500 | lumiopen_math500 |
+|--------------------------|--------------------|-------------------|------------------|
+| Llama-Poro-2-8B-Instruct | 0.47               | 0                 | 0.444            |
+| Qwen/Qwen3-8B            | 0.956              | 0                 | 0.888            |

--- a/lm_eval/tasks/lumiopen/math500.yaml
+++ b/lm_eval/tasks/lumiopen/math500.yaml
@@ -1,0 +1,26 @@
+tag:
+  - math_word_problems
+task: lumiopen_math500
+dataset_path: HuggingFaceH4/MATH-500
+process_docs: !function utils.process_docs
+dataset_name: default
+output_type: generate_until
+training_split: null
+test_split: test
+doc_to_text: "{{problem}}"
+process_results: !function utils.process_results
+doc_to_target: "{{answer}}"
+generation_kwargs:
+  until:
+    - "</s>"
+    - "<|im_end|>"
+    - "<|eot_id|>"
+  do_sample: false
+  temperature: 0.0 # TODO: We should do repeats with temperature > 0
+  max_gen_toks: 32768
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/lumiopen/math500fi.yaml
+++ b/lm_eval/tasks/lumiopen/math500fi.yaml
@@ -1,5 +1,5 @@
 include: math500.yaml
-task: lumiopen_math500fi
+task: lumiopen_math500_mt_fi
 process_docs: !function utils.process_docs_fi
 dataset_name: default
 dataset_path: Chaanim/math_500_fi

--- a/lm_eval/tasks/lumiopen/math500fi.yaml
+++ b/lm_eval/tasks/lumiopen/math500fi.yaml
@@ -1,0 +1,7 @@
+include: math500.yaml
+task: lumiopen_math500fi
+process_docs: !function utils.process_docs_fi
+dataset_name: default
+dataset_path: Chaanim/math_500_fi
+training_split: null
+test_split: test

--- a/lm_eval/tasks/lumiopen/utils.py
+++ b/lm_eval/tasks/lumiopen/utils.py
@@ -10,7 +10,8 @@ Solve the following problem. The final line of your response MUST be of the foll
 """.strip()
 
 MATH_QUERY_TEMPLATE_FI = """
-Ratkaise seuraava matemaattinen ongelma. Varmista, että vastaus (ja vain vastaus) sijoitetaan \\boxed{{}} sisään.
+Ratkaise seuraava matemaattinen ongelma. Vastauksesi viimeisen rivin TULEE OLLA muodossa:
+"VASTAUS: $\\boxed{{VASTAUS}}$" (ilman lainausmerkkejä), missä $VASTAUS on lopullinen vastaus. Ennen vastaamista, ajattele vaihe vaiheelta miten ongelma ratkaistaan.
 
 {prompt}
 """.strip()

--- a/lm_eval/tasks/lumiopen/utils.py
+++ b/lm_eval/tasks/lumiopen/utils.py
@@ -1,0 +1,260 @@
+from typing import Dict, List
+
+import datasets
+
+MATH_QUERY_TEMPLATE = """
+Solve the following problem. The final line of your response MUST be of the following format:
+"ANSWER: $\\boxed{{ANSWER}}$" (without quotes) where $ANSWER is the final answer. Think step by step before answering.
+
+{prompt}
+""".strip()
+
+MATH_QUERY_TEMPLATE_FI = """
+Ratkaise seuraava matemaattinen ongelma. Varmista, että vastaus (ja vain vastaus) sijoitetaan \\boxed{{}} sisään.
+
+{prompt}
+""".strip()
+
+def process_docs(dataset: datasets.Dataset) -> datasets.Dataset:
+    def _process_doc(doc: dict) -> dict:
+        out_doc = {
+            "problem": MATH_QUERY_TEMPLATE.format(prompt=doc["problem"]),
+            "solution": doc["solution"],
+            "answer": remove_boxed(last_boxed_only_string(doc["solution"])),
+        }
+        return out_doc
+
+    return dataset.map(_process_doc)
+
+def process_docs_fi(dataset: datasets.Dataset) -> datasets.Dataset:
+    def _process_doc(doc: dict) -> dict:
+        out_doc = {
+            "problem": MATH_QUERY_TEMPLATE_FI.format(prompt=doc["problem"]),
+            "solution": doc["solution"],
+            "answer": remove_boxed(last_boxed_only_string(doc["solution"])),
+        }
+        return out_doc
+
+    return dataset.map(_process_doc)
+
+
+def process_results(doc: dict, results: List[str]) -> Dict[str, int]:
+    retval = 0
+    indices = [pos for pos, char in enumerate(results[0]) if char == "$"]
+    if len(indices) <= 1:
+        answer = results[0]
+    else:
+        answer = results[0][indices[0] + 1 : indices[-1]]
+
+    # Extract the answer in the same way as the solution
+    answer = last_boxed_only_string(results[0])
+    if answer:
+        answer = remove_boxed(answer)
+    print("ANSWER:", answer)
+    print("EXPECTED:", remove_boxed(last_boxed_only_string(doc["solution"])))
+    if is_equiv(answer, remove_boxed(last_boxed_only_string(doc["solution"]))):
+        retval = 1
+
+    results = {
+        "exact_match": retval,
+    }
+    return results
+
+
+# string normalization from https://github.com/EleutherAI/lm-evaluation-harness/blob/master/lm_eval/tasks/hendrycks_math.py
+def is_equiv(str1, str2, verbose=False):
+    if str1 is None and str2 is None:
+        print("WARNING: Both None")
+        return True
+    if str1 is None or str2 is None:
+        return False
+
+    try:
+        ss1 = strip_string(str1)
+        ss2 = strip_string(str2)
+        if verbose:
+            print(ss1, ss2)
+        return ss1 == ss2
+    except Exception:
+        return str1 == str2
+
+
+def remove_boxed(s):
+    if "\\boxed " in s:
+        left = "\\boxed "
+        assert s[: len(left)] == left
+        return s[len(left) :]
+
+    left = "\\boxed{"
+
+    assert s[: len(left)] == left
+    assert s[-1] == "}"
+
+    return s[len(left) : -1]
+
+
+def last_boxed_only_string(string):
+    idx = string.rfind("\\boxed")
+    if "\\boxed " in string:
+        return "\\boxed " + string.split("\\boxed ")[-1].split("$")[0]
+    if idx < 0:
+        idx = string.rfind("\\fbox")
+        if idx < 0:
+            return None
+
+    i = idx
+    right_brace_idx = None
+    num_left_braces_open = 0
+    while i < len(string):
+        if string[i] == "{":
+            num_left_braces_open += 1
+        if string[i] == "}":
+            num_left_braces_open -= 1
+            if num_left_braces_open == 0:
+                right_brace_idx = i
+                break
+        i += 1
+
+    if right_brace_idx is None:
+        retval = None
+    else:
+        retval = string[idx : right_brace_idx + 1]
+
+    return retval
+
+
+def fix_fracs(string):
+    substrs = string.split("\\frac")
+    new_str = substrs[0]
+    if len(substrs) > 1:
+        substrs = substrs[1:]
+        for substr in substrs:
+            new_str += "\\frac"
+            if substr[0] == "{":
+                new_str += substr
+            else:
+                try:
+                    assert len(substr) >= 2
+                except AssertionError:
+                    return string
+                a = substr[0]
+                b = substr[1]
+                if b != "{":
+                    if len(substr) > 2:
+                        post_substr = substr[2:]
+                        new_str += "{" + a + "}{" + b + "}" + post_substr
+                    else:
+                        new_str += "{" + a + "}{" + b + "}"
+                else:
+                    if len(substr) > 2:
+                        post_substr = substr[2:]
+                        new_str += "{" + a + "}" + b + post_substr
+                    else:
+                        new_str += "{" + a + "}" + b
+    string = new_str
+    return string
+
+
+def fix_a_slash_b(string):
+    if len(string.split("/")) != 2:
+        return string
+    a = string.split("/")[0]
+    b = string.split("/")[1]
+    try:
+        a = int(a)
+        b = int(b)
+        assert string == "{}/{}".format(a, b)
+        new_string = "\\frac{" + str(a) + "}{" + str(b) + "}"
+        return new_string
+    except AssertionError:
+        return string
+
+
+def remove_right_units(string):
+    # "\\text{ " only ever occurs (at least in the val set) when describing units
+    if "\\text{ " in string:
+        splits = string.split("\\text{ ")
+        assert len(splits) == 2
+        return splits[0]
+    else:
+        return string
+
+
+def fix_sqrt(string):
+    if "\\sqrt" not in string:
+        return string
+    splits = string.split("\\sqrt")
+    new_string = splits[0]
+    for split in splits[1:]:
+        if split[0] != "{":
+            a = split[0]
+            new_substr = "\\sqrt{" + a + "}" + split[1:]
+        else:
+            new_substr = "\\sqrt" + split
+        new_string += new_substr
+    return new_string
+
+
+def strip_string(string):
+    # linebreaks
+    string = string.replace("\n", "")
+
+    # remove inverse spaces
+    string = string.replace("\\!", "")
+
+    # replace \\ with \
+    string = string.replace("\\\\", "\\")
+
+    # replace tfrac and dfrac with frac
+    string = string.replace("tfrac", "frac")
+    string = string.replace("dfrac", "frac")
+
+    # remove \left and \right
+    string = string.replace("\\left", "")
+    string = string.replace("\\right", "")
+
+    # Remove circ (degrees)
+    string = string.replace("^{\\circ}", "")
+    string = string.replace("^\\circ", "")
+
+    # remove dollar signs
+    string = string.replace("\\$", "")
+
+    # remove units (on the right)
+    string = remove_right_units(string)
+
+    # remove percentage
+    string = string.replace("\\%", "")
+    string = string.replace("\%", "")  # noqa: W605
+
+    # " 0." equivalent to " ." and "{0." equivalent to "{." Alternatively, add "0" if "." is the start of the string
+    string = string.replace(" .", " 0.")
+    string = string.replace("{.", "{0.")
+    # if empty, return empty string
+    if len(string) == 0:
+        return string
+    if string[0] == ".":
+        string = "0" + string
+
+    # to consider: get rid of e.g. "k = " or "q = " at beginning
+    if len(string.split("=")) == 2:
+        if len(string.split("=")[0]) <= 2:
+            string = string.split("=")[1]
+
+    # fix sqrt3 --> sqrt{3}
+    string = fix_sqrt(string)
+
+    # remove spaces
+    string = string.replace(" ", "")
+
+    # \frac1b or \frac12 --> \frac{1}{b} and \frac{1}{2}, etc. Even works with \frac1{72} (but not \frac{72}1). Also does a/b --> \\frac{a}{b}
+    string = fix_fracs(string)
+
+    # manually change 0.5 --> \frac{1}{2}
+    if string == "0.5":
+        string = "\\frac{1}{2}"
+
+    # NOTE: X/Y changed to \frac{X}{Y} in dataset, but in simple cases fix in case the model output is X/Y
+    string = fix_a_slash_b(string)
+
+    return string

--- a/lm_eval/tasks/lumiopen/utils.py
+++ b/lm_eval/tasks/lumiopen/utils.py
@@ -40,12 +40,6 @@ def process_docs_fi(dataset: datasets.Dataset) -> datasets.Dataset:
 
 def process_results(doc: dict, results: List[str]) -> Dict[str, int]:
     retval = 0
-    indices = [pos for pos, char in enumerate(results[0]) if char == "$"]
-    if len(indices) <= 1:
-        answer = results[0]
-    else:
-        answer = results[0][indices[0] + 1 : indices[-1]]
-
     # Extract the answer in the same way as the solution
     answer = last_boxed_only_string(results[0])
     if answer:

--- a/lm_eval/tasks/lumiopen/utils.py
+++ b/lm_eval/tasks/lumiopen/utils.py
@@ -44,8 +44,6 @@ def process_results(doc: dict, results: List[str]) -> Dict[str, int]:
     answer = last_boxed_only_string(results[0])
     if answer:
         answer = remove_boxed(answer)
-    print("ANSWER:", answer)
-    print("EXPECTED:", remove_boxed(last_boxed_only_string(doc["solution"])))
     if is_equiv(answer, remove_boxed(last_boxed_only_string(doc["solution"]))):
         retval = 1
 


### PR DESCRIPTION
This PR contains English and Finnish Math-500 evals. These evals use prompts targeted for instruction tuned models (adapted from lighteval), unlike the existing math-500 implementation in lm-eval-harness. Parsing the final answer has also been improved, but is not as good as in lighteval. This implementation uses greedy decoding with no repeats like the existing math-500 implementation in lm-eval-harness, although this is not the standard way in the literature.

### Score comparison between lighteval and this implementation:
**lighteval**
LumiOpen/Llama-Poro-2-8B-Instruct math-500 en: 0.47
LumiOpen/Llama-Poro-2-8B-Instruct math-500 fi: 0.326
Qwen/Qwen3-8B math-500 en: 0.956
Qwen/Qwen3-8B math-500 fi: 0.9

**This implementation:**
LumiOpen/Llama-Poro-2-8B-Instruct math-500 en: 0.444
LumiOpen/Llama-Poro-2-8B-Instruct math-500 fi: 0.342
Qwen/Qwen3-8B math-500 en: 0.888
Qwen/Qwen3-8B math-500 fi: 0.846